### PR TITLE
Remove trailing comma which causes a syntax error

### DIFF
--- a/install.php
+++ b/install.php
@@ -163,7 +163,7 @@ if (isset($_POST["submit"])) {
 				$data[4], $data[5], $data[6], $data[7],
 				$data[8], $data[9], $data[10], $data[11],
 				$data[12], $data[13], $data[14], $data[15],
-				$data[16], $com, $data[18], $data[19],
+				$data[16], $com, $data[18], $data[19]
 			);
 			if (!($stmt->execute())) {
 				echo "<br>FAILURE on post #".$data[0]."\n";


### PR DESCRIPTION
Parse error: syntax error, unexpected ')' in [path-to-kokonotsuba-directory]/install.php on line 167

The syntax error is resolved by removing the trailing comma inside of the bind_param().

Tested in PHP 7.2
Apache/2.4.29 (Ubuntu)
MySQL