### PR TITLE
Update LICENSE to require credit to heyuri

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -12,6 +12,9 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
+Credit to www.heyuri.net must be included in all copies or substantial portions
+of the Software.
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE


### PR DESCRIPTION
It is allowed to add more conditions onto the MIT license, so it might help to clarify that Heyuri must be credited in the LICENSE rather than in koko.php