### PR TITLE
Add SWF Embeds (enhancement)

### DIFF
--- a/config.php
+++ b/config.php
@@ -151,6 +151,7 @@ define("STORAGE_LIMIT", 0); // storage limit
 define("STORAGE_MAX", 300000); // total storage limit
 define("ALLOW_UPLOAD_EXT", 'GIF|JPG|JPEG|PNG|BMP|SWF|WEBM|MP4'); // Allowed filetypes
 define("VIDEO_EXT", 'WEBM|MP4'); // What filetypes will be loaded as a video
+define("SWF_THUMB", STATIC_URL."swf_thumb.png");
 
 // Continuous Posting Time Limits
 define("RENZOKU", 0); // Post limit, intervals in seconds

--- a/js/img.js
+++ b/js/img.js
@@ -274,6 +274,7 @@ const kkimg = { name: "KK Image Features",
 	postimg: null,
 	imgext: Array("png","jpg","jpeg","gif","giff","bmp","jfif"),
 	vidext: Array("webm","mp4"),
+	swfext: Array("webm","mp4"),
 	/* event */
 	_evexpand: function (event) {
 		if (localStorage.getItem("imgexpand")!="true") return;
@@ -313,6 +314,15 @@ const kkimg = { name: "KK Image Features",
 			a.insertAdjacentHTML("afterend", '<div class="expand">'+
 				'<div>[<a href="javascript:kkimg.contract(\''+no+'\');">Close</a>]</div>'+
 				'<video controls="controls" loop="loop" autoplay="autoplay" src="'+a.href+'"></video>'+
+			'</div>');
+			return true;
+		} else if (kkimg.swfext.includes(ext)) {
+			a.insertAdjacentHTML("afterend", '<div class="expand">'+
+				'<div>[<a href="javascript:kkimg.contract(\''+no+'\');">Close</a>]</div>'+
+				'<object width="640" height="480">'+
+				'<param name="movie" value="'+a.href+'">'+
+				'<embed src="'+a.href+'" width="640" height="480">'+
+				'</embed></object>'+
 			'</div>');
 			return true;
 		}

--- a/js/img.js
+++ b/js/img.js
@@ -274,7 +274,7 @@ const kkimg = { name: "KK Image Features",
 	postimg: null,
 	imgext: Array("png","jpg","jpeg","gif","giff","bmp","jfif"),
 	vidext: Array("webm","mp4"),
-	swfext: Array("webm","mp4"),
+	swfext: Array("swf"),
 	/* event */
 	_evexpand: function (event) {
 		if (localStorage.getItem("imgexpand")!="true") return;

--- a/koko.php
+++ b/koko.php
@@ -305,6 +305,8 @@ function arrangeThread($PTE, $tree, $tree_cut, $posts, $hiddenReply, $resno=0, $
 					$imgsrc = '<a href="'.$imageURL.'" target="_blank" rel="nofollow"><img src="'.$thumbURL.'" width="'.$tw.'" height="'.$th.'" class="postimg" alt="'.$imgsize.'" title="Click to show full image" hspace="20" vspace="3" border="0" align="left" /></a>';
 				}
 				if(SHOW_IMGWH) $imgwh_bar = ', '.$imgw.'x'.$imgh; // Displays the original length and width dimensions of the attached image file
+			} else if ($ext = "swf") {
+				$imgsrc = '<a href="'.$imageURL.'" target="_blank" rel="nofollow"><img src="'.SWF_THUMB.'" class="postimg" alt="SWF Embed" hspace="20" vspace="3" border="0" align="left" /></a>'; // Default display style (when no preview image)
 			} else $imgsrc = '';
 			$IMG_BAR = _T('img_filename').'<a href="'.$imageURL.'" target="_blank" rel="nofollow" onmouseover="this.textContent=\''.$fname.'\';" onmouseout="this.textContent=\''.$truncated.'\'"> '.$truncated.'</a> <a href="'.$imageURL.'" download="'.$fname.'"><div class="download"></div></a> <small>('.$imgsize.$imgwh_bar.')</small> '.$img_thumb;
 		}


### PR DESCRIPTION
My pull request adds the following:
- The ability to embed SWF files in  `/js/img.js`.
- Add a custom SWF thumbnail icon to `koko.php`.
- Adds a setting to change the icon in `config.php`.

My changes will add a Flash icon thumbnail and an embed.

Tested Setup:
- Windows 10 1903 x64.
- XAMPP Version 7.4.22 (Apache 2.4.48)
- PHP 7.4.22 (VC15 X86 64bit thread safe)
- MariaDB 10.4.20

Please check the changes out and if they can be improved.
Thank you so much! 
