### PR TITLE
Fixed links to work at footer of the site

### DIFF
--- a/lib/lib_common.php
+++ b/lib/lib_common.php
@@ -130,7 +130,7 @@ function foot(&$dat,$res=false){
 
 	$pte_vals = array('{$FOOTER}'=>'','{$IS_THREAD}'=>$res);
 	$PMS->useModuleMethods('Foot', array(&$pte_vals['{$FOOTER}'])); // "Foot" Hook Point
-	$pte_vals['{$FOOTER}'] .= '<center>- <a rel="nofollow noreferrer license" href="https://web.archive.org/web/20150701123900/http://php.s3.to/" target="_blank">GazouBBS</a> + <a rel="nofollow noreferrer license" href="http://www.2chan.net/" target="_blank">futaba</a> + <a rel="nofollow noreferrer license" href="https://pixmicat.github.io/" target="_blank">Pixmicat!</a> + <a rel="nofollow noreferrer license" href="https://www.kolyma.org/software/kokonotsuba/" target="_blank" title="Developed by Deadking for Kolyma Network">Kokonotsuba</a> -</center>';
+	$pte_vals['{$FOOTER}'] .= '<center>- <a rel="nofollow noreferrer license" href="https://web.archive.org/web/20150701123900/http://php.s3.to/" target="_blank">GazouBBS</a> + <a rel="nofollow noreferrer license" href="http://www.2chan.net/" target="_blank">futaba</a> + <a rel="nofollow noreferrer license" href="https://pixmicat.github.io/" target="_blank">Pixmicat!</a> + <a rel="nofollow noreferrer license" href="https://github.com/Heyuri/kokonotsuba/" target="_blank" title="Developed by Deadking for Kolyma Network">Kokonotsuba</a> -</center>';
 	$dat .= $PTE->ParseBlock('FOOTER',$pte_vals);
 }
 

--- a/lib/lib_common.php
+++ b/lib/lib_common.php
@@ -130,7 +130,7 @@ function foot(&$dat,$res=false){
 
 	$pte_vals = array('{$FOOTER}'=>'','{$IS_THREAD}'=>$res);
 	$PMS->useModuleMethods('Foot', array(&$pte_vals['{$FOOTER}'])); // "Foot" Hook Point
-	$pte_vals['{$FOOTER}'] .= '<center>- <a rel="nofollow noreferrer license" href="http://php.s3.to" target="_blank">GazouBBS</a> + <a rel="nofollow noreferrer license" href="http://www.2chan.net/" target="_blank">futaba</a> + <a rel="nofollow noreferrer license" href="http://pixmicat.openfoundry.org/" target="_blank">Pixmicat!</a> + <a rel="nofollow noreferrer license" href="https://kokonotsuba.kuz.lol" target="_blank" title="Developed by Deadking for Kolyma Network">Kokonotsuba</a> -</center>';
+	$pte_vals['{$FOOTER}'] .= '<center>- <a rel="nofollow noreferrer license" href="https://web.archive.org/web/20150701123900/http://php.s3.to/" target="_blank">GazouBBS</a> + <a rel="nofollow noreferrer license" href="http://www.2chan.net/" target="_blank">futaba</a> + <a rel="nofollow noreferrer license" href="https://pixmicat.github.io/" target="_blank">Pixmicat!</a> + <a rel="nofollow noreferrer license" href="https://www.kolyma.org/software/kokonotsuba/" target="_blank" title="Developed by Deadking for Kolyma Network">Kokonotsuba</a> -</center>';
 	$dat .= $PTE->ParseBlock('FOOTER',$pte_vals);
 }
 


### PR DESCRIPTION
# Pull Request
Working footer links! ![happy yotsuba](https://static.heyuri.net/koko/image/emote/emo-yotsuba-biggrin.gif)

- [X] In the case that it is a fix: Highlights what issue the pull request is fixing
  - My pull request plans to fix the anchor hrefs in lib_common.php which appear as hyper links on the bottom of the website
- [X] Summarizes what the changes will do
  - 3/4 links at the bottom of the website were linked to broken/dead sites 
  - My changes will make the GazouBBS, Pixmicat!, Kokonotsuba links work properly.
- [X] Has been tested, preferably with this parameters
  - Debian 10
  - nginx
  - MariaDB
  - PHP 7.3
    - If you're unable to, just test it on your system, as in most cases it will work on Heyuri too 

![le cool yotsuba](https://static.heyuri.net/koko/image/emote/emo-yotsuba-cool.gif)