### PR TITLE
Deny access automatically to /dat if apache is used

### DIFF
--- a/dat/.htaccess
+++ b/dat/.htaccess
@@ -1,0 +1,1 @@
+deny from all


### PR DESCRIPTION
As such folder is not supposed to be accessible, an .htaccess denying access for anyone using apache should be added.

Even though apache is not supported, it is very likely that some are using it anyway and the .htaccess file isn't harmful to have on NGINX.