### PR TITLE
Anti-flood module

### DIFF
--- a/lib/pio/pio.mysqli.php
+++ b/lib/pio/pio.mysqli.php
@@ -327,6 +327,16 @@ class PIOmysqli implements IPIO {
 		}
 		return 0;
 	}
+	
+	/* Get the last thread post time */
+	public function getLastThreadTime() {
+		if(!$this->prepared) $this->dbPrepare();
+		
+		$tree = $this->_mysql_call('SELECT MAX(time) AS last FROM '.$this->tablename.' WHERE resto = 0', array('Failed to get last thread time', __LINE__));
+		$last = $tree->fetch_row();
+		$tree->free();
+		return $last[0];
+	}
 
 	/* Output list of articles */
 	public function fetchPostList($resno=0, $start=0, $amount=0){

--- a/module/mod_antiflood.php
+++ b/module/mod_antiflood.php
@@ -1,0 +1,30 @@
+<?php
+// by komeo
+class mod_antiflood extends ModuleHelper {
+	private $mypage;
+	private $CONNECTION_STRING = CONNECTION_STRING;
+	private $RENZOKU3 = 10; // Seconds before a new thread can be made
+
+	public function __construct($PMS) {
+		parent::__construct($PMS);
+		$this->mypage = $this->getModulePageURL();
+	}
+
+	public function getModuleName() {
+		return __CLASS__.' : Anti-flood';
+	}
+
+	public function getModuleVersionInfo() {
+		return 'Koko BBS Release 1';
+	}
+	
+	public function autoHookRegistBegin(&$name, &$email, &$sub, &$com, $upfileInfo, $accessInfo, $isReply){
+		if ($isReply == 0) {
+			$PIO = PMCLibrary::getPIOInstance();
+			$last = $PIO->getLastThreadTime();
+			$now = $_SERVER["REQUEST_TIME"];
+			if ($now - $last < $this->RENZOKU3) error('ERROR: Please wait a few seconds before creating a new thread.');
+		}
+	}
+}
+?>


### PR DESCRIPTION
closes #53 

Anti-flood module that prevents spamming new threads, like RENZOKU but without taking IPs into account.
<getLastThreadTime> could've been in the module but i think there's something wrong with PIO's <_mysql_call> function, you cannot fetch anything from it.