### PR TITLE
Catalog thumbnails fix

### DIFF
--- a/config.php
+++ b/config.php
@@ -170,11 +170,11 @@ define("MAX_W", 250); // Max Width
 define("MAX_H", 250); // Max Height
 define("MAX_RW", 125); // Reply Max Width
 define("MAX_RH", 125); // Reply Max Height
-$THUMB_SETTING = array( // Thumbnail Gen. Settings
+define("THUMB_SETTING", array( // Thumbnail Gen. Settings
 	'Method' => 'gd', //gd (default), imagemagick, imagick, magickwand, repng2jpeg
 	'Format' => 'png',
 	'Quality' => 75
-);
+));
 
 // Appearance
 $ADDITION_INFO = @file_get_contents(ROOTPATH.'addinfo.txt'); // Addinfo

--- a/koko.php
+++ b/koko.php
@@ -422,7 +422,7 @@ function previewPost($tmpno) {
 
 /* Write to log file */
 function regist($preview=false){
-	global $BAD_STRING, $BAD_FILEMD5, $BAD_IPADDR, $LIMIT_SENSOR, $THUMB_SETTING;
+	global $BAD_STRING, $BAD_FILEMD5, $BAD_IPADDR, $LIMIT_SENSOR;
 	$PIO = PMCLibrary::getPIOInstance();
 	$FileIO = PMCLibrary::getFileIOInstance();
 	$PMS = PMCLibrary::getPMSInstance();
@@ -818,17 +818,17 @@ function regist($preview=false){
 	setcookie('emailc', $email, time()+7*24*3600);
 	if($dest && is_file($dest)){
 		$destFile = IMG_DIR.$tim.$ext; // Image file storage location
-		$thumbFile = THUMB_DIR.$tim.'s.'.$THUMB_SETTING['Format']; // Preview image storage location
+		$thumbFile = THUMB_DIR.$tim.'s.'.THUMB_SETTING['Format']; // Preview image storage location
 		if (defined(CDN_DIR)) {
 			$destFile = CDN_DIR.$destFile;
 			$thumbFile = CDN_DIR.$thumbFile;
 		}
 		if(USE_THUMB !== 0){ // Generate preview image
-			$thumbType = USE_THUMB; if(USE_THUMB==1){ $thumbType = $THUMB_SETTING['Method']; }
+			$thumbType = USE_THUMB; if(USE_THUMB==1){ $thumbType = THUMB_SETTING['Method']; }
 			require(ROOTPATH.'lib/thumb/thumb.'.$thumbType.'.php');
 			if (isset($tmpfile)) $thObj = new ThumbWrapper($tmpfile, $imgW, $imgH);
 			else $thObj = new ThumbWrapper($dest, $imgW, $imgH);
-			$thObj->setThumbnailConfig($W, $H, $THUMB_SETTING);
+			$thObj->setThumbnailConfig($W, $H, THUMB_SETTING);
 			$thObj->makeThumbnailtoFile($thumbFile);
 			@chmod($thumbFile, 0666);
 			unset($thObj);
@@ -839,7 +839,7 @@ function regist($preview=false){
 			$delta_totalsize += filesize($destFile);
 		}
 		if(file_exists($thumbFile)){
-			$FileIO->uploadImage($tim.'s.'.$THUMB_SETTING['Format'], $thumbFile, filesize($thumbFile));
+			$FileIO->uploadImage($tim.'s.'.THUMB_SETTING['Format'], $thumbFile, filesize($thumbFile));
 			$delta_totalsize += filesize($thumbFile);
 		}
 	}
@@ -1258,7 +1258,7 @@ function deleteCache($no){
 
 /* Display system information */
 function showstatus(){
-	global $LIMIT_SENSOR, $THUMB_SETTING;
+	global $LIMIT_SENSOR;
 	$PIO = PMCLibrary::getPIOInstance();
 	$FileIO = PMCLibrary::getFileIOInstance();
 	$PTE = PMCLibrary::getPTEInstance();
@@ -1314,7 +1314,7 @@ function showstatus(){
 		<tr><td>'._T('info_basic_com_limit').'</td><td colspan="3"> '.COMM_MAX._T('info_basic_com_after').'</td></tr>
 		<tr><td>'._T('info_basic_anonpost').'</td><td colspan="3"> '.ALLOW_NONAME.' '._T('info_basic_anonpost_opt').'</td></tr>
 		<tr><td>'._T('info_basic_del_incomplete').'</td><td colspan="3"> '.KILL_INCOMPLETE_UPLOAD.' '._T('info_0no1yes').'</td></tr>
-		<tr><td>'._T('info_basic_use_sample', $THUMB_SETTING['Quality']).'</td><td colspan="3"> '.USE_THUMB.' '._T('info_0notuse1use').'</td></tr>
+		<tr><td>'._T('info_basic_use_sample', THUMB_SETTING['Quality']).'</td><td colspan="3"> '.USE_THUMB.' '._T('info_0notuse1use').'</td></tr>
 		<tr><td>'._T('info_basic_useblock').'</td><td colspan="3"> '.BAN_CHECK.' '._T('info_0disable1enable').'</td></tr>
 		<tr><td>'._T('info_basic_showid').'</td><td colspan="3"> '.DISP_ID.' '._T('info_basic_showid_after').'</td></tr>
 		<tr><td>'._T('info_basic_cr_limit').'</td><td colspan="3"> '.BR_CHECK._T('info_basic_cr_after').'</td></tr>

--- a/module/mod_cat.php
+++ b/module/mod_cat.php
@@ -4,6 +4,7 @@ class mod_cat extends ModuleHelper {
 	private $mypage;
 	private $PAGE_DEF = 1000;
 	private $RESICON = STATIC_URL.'/image/replies.png';
+	private $THUMB_EXT = THUMB_SETTING['Format'];
 
 	public function __construct($PMS) {
 		parent::__construct($PMS);
@@ -28,6 +29,7 @@ class mod_cat extends ModuleHelper {
 		$PIO = PMCLibrary::getPIOInstance();
 		$FileIO = PMCLibrary::getFileIOInstance();
 		$dat = '';
+		$THUMB_EXT = $THUMB_SETTING['Format'];
 
 		$list_max = $PIO->postCount();
 		$page = $_GET['page']??0;
@@ -105,7 +107,7 @@ class mod_cat extends ModuleHelper {
 			$dat.= '<td class="thread" width="180" height="200" align="CENTER">
 	<div class="filesize">'.$arrLabels['{$IMG_BAR}'].'</div>
 	<a href="'.PHP_SELF.'?res='.($resto?$resto:$no).'#p'.$no.'">'.
-	($FileIO->imageExists($tim.$ext) ? '<img src="'.$FileIO->getImageURL($tim.'s.jpg').'" width="'.min(150, $tw).'" vspace="3"	class="thumb" />' : '***').
+	($FileIO->imageExists($tim.$ext) ? '<img src="'.$FileIO->getImageURL($tim.'s.'.$this->THUMB_EXT).'" width="'.min(150, $tw).'" vspace="3"	class="thumb" />' : '***').
 	'</a><br />
 	<nobr><small><b class="title">'.substr($sub, 0, 20).'</b>:'.
 		$arrLabels['{$POSTINFO_EXTRA}'].'&nbsp;<span title="Replies"><img src="'.$this->RESICON.'" class="icon" /> '.$res.'</small></span></nobr><br />

--- a/module/mod_cat.php
+++ b/module/mod_cat.php
@@ -29,7 +29,6 @@ class mod_cat extends ModuleHelper {
 		$PIO = PMCLibrary::getPIOInstance();
 		$FileIO = PMCLibrary::getFileIOInstance();
 		$dat = '';
-		$THUMB_EXT = $THUMB_SETTING['Format'];
 
 		$list_max = $PIO->postCount();
 		$page = $_GET['page']??0;


### PR DESCRIPTION
closes #7 
Proper fix for said issue, $THUMB_SETTING in config.php now uses `define()` since PHP >7 supports defining arrays.