### PR TITLE
each __construct

### DIFF
--- a/koko.php
+++ b/koko.php
@@ -932,14 +932,14 @@ function usrdel(){
 	$onlyimgdel = $_POST['onlyimgdel']??'';
 	$delno = array();
 	reset($_POST);
-	while ($item = each($_POST)){
-		if ($item[1] !== 'delete') {
+	foreach($_POST as $key=>$val){
+		if (!is_numeric($key)) {
 			continue;
 		}
-		if (!is_numeric($item[0])) {
-			continue;
+		if($val==='delete'){
+			array_push($delno,$key);
+			$delflag=TRUE;
 		}
-		array_push($delno, intval($item[0]));
 	}
 	$haveperm = valid()>=LEV_JANITOR;
 	$PMS->useModuleMethods('Authenticate', array($pwd,'userdel',&$haveperm));

--- a/lib/lib_pio.php
+++ b/lib/lib_pio.php
@@ -7,7 +7,7 @@ PIO - Pixmicat! data source I/O
 class FlagHelper{
 	var $_status;
 
-	function FlagHelper($status=''){
+	function __construct($status=''){
 		$this->_write($status);
 	}
 

--- a/lib/lib_pms.php
+++ b/lib/lib_pms.php
@@ -17,7 +17,7 @@ class PMS{
 	var $CHPList;
 
 	/* Constructor */
-	function PMS($ENV){
+	function __construct($ENV){
 		$this->loaded = false; // 是否載入完成 (模組及函式)
 		$this->ENV = $ENV; // 環境變數
 		$this->hooks = array_flip(array('Head', 'Toplink', 'LinksAboveBar', 'PostInfo',

--- a/lib/lib_pte.php
+++ b/lib/lib_pte.php
@@ -17,7 +17,7 @@ class PTELibrary{
 	var $tpl_block, $tpl;
 
 	/* 開啟樣板檔案並取出區塊 */
-	function PTELibrary($tplname){
+	function __construct($tplname){
 		$this->tpl_block = array();
 		$this->tpl = file_get_contents($tplname);
 	}

--- a/lib/thumb/thumb.gd.php
+++ b/lib/thumb/thumb.gd.php
@@ -12,7 +12,7 @@
 class ThumbWrapper{
 	var $sourceFile, $sourceWidth, $sourceHeight, $thumbWidth, $thumbHeight, $thumbSetting, $thumbQuality;
 
-	function ThumbWrapper($sourceFile='', $sourceWidth=0, $sourceHeight=0){
+	function __construct($sourceFile='', $sourceWidth=0, $sourceHeight=0){
 		$this->sourceFile = $sourceFile;
 		$this->sourceWidth = $sourceWidth;
 		$this->sourceHeight = $sourceHeight;


### PR DESCRIPTION
The deletion process performed by `each` has been replaced with `foreach`.

https://www.php.net/manual/en/function.each.php
>This function has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0. Relying on this function is highly discouraged.

https://www.php.net/manual/en/migration70.deprecated.php
> PHP 4 style constructors (methods that have the same name as the class they are defined in) are deprecated, and will be removed in the future. PHP 7 will emit E_DEPRECATED if a PHP 4 constructor is the only constructor defined within a class. Classes that implement a __construct() method are unaffected.