### PR TITLE
Fix for deprecated syntax

### DIFF
--- a/koko.php
+++ b/koko.php
@@ -261,7 +261,8 @@ function updatelog($resno=0,$pagenum=-1,$single_page=false){
 }
 
 /* Output thread schema */
-function arrangeThread($PTE, $tree, $tree_cut, $posts, $hiddenReply, $resno=0, $arr_kill, $arr_old, $kill_sensor, $old_sensor, $showquotelink=true, $adminMode=false, $threads_shown=0){
+function arrangeThread($PTE, $tree, $tree_cut, $posts, $hiddenReply, $resno, $arr_kill, $arr_old, $kill_sensor, $old_sensor, $showquotelink=true, $adminMode=false, $threads_shown=0){
+	$resno = isset($resno) && $resno ? $resno : 0;
 	$PIO = PMCLibrary::getPIOInstance();
 	$FileIO = PMCLibrary::getFileIOInstance();
 	$PMS = PMCLibrary::getPMSInstance();

--- a/lib/lib_common.php
+++ b/lib/lib_common.php
@@ -315,7 +315,7 @@ function BanIPHostDNSBLCheck($IP, $HOST, &$baninfo){
 	if($IsBanned){ $baninfo = _T('ip_banned'); return true; }
 
 	// DNS-based Blackhole List(DNSBL) 黑名單
-	if(!$DNSBLservers[0]) return false; // Skip check
+	if(!isset($DNSBLservers[0])||!$DNSBLservers[0]) return false; // Skip check
 	if(array_search($IP, $DNSBLWHlist)!==false) return false; // IP位置在白名單內
 	$rev = implode('.', array_reverse(explode('.', $IP)));
 	$lastPoint = count($DNSBLservers) - 1; if($DNSBLservers[0] < $lastPoint) $lastPoint = $DNSBLservers[0];

--- a/lib/lib_pio.php
+++ b/lib/lib_pio.php
@@ -43,25 +43,25 @@ class FlagHelper{
 	function update($flag, $value=null){
 		if($value===null){
 			$ifexist = $this->get($flag);
-			if($ifexist !== $flag) $this->_write($this->toString()."_${flag}_");
+			if($ifexist !== $flag) $this->_write($this->toString()."_{$flag}_");
 		}else{
 			if(is_array($value)) $value = $this->join($value); // Array Flatten
 			$ifexist = $this->get($flag);
 			if($ifexist !== $flag.':'.$value){
 				if($ifexist) $this->_write($this->replace($ifexist, "$flag:$value")); // 已立flag，不同值
-				else $this->_write($this->toString()."_$flag:${value}_"); // 無flag
+				else $this->_write($this->toString()."_$flag:{$value}_"); // 無flag
 			}
 		}
 		return $this;
 	}
 
 	function replace($from, $to){
-		return str_replace("_${from}_", "_${to}_", $this->toString());
+		return str_replace("_{$from}_", "_{$to}_", $this->toString());
 	}
 
 	function remove($flag){
 		$wholeflag = $this->get($flag);
-		$this->_write(str_replace("_${wholeflag}_", '', $this->toString()));
+		$this->_write(str_replace("_{$wholeflag}_", '', $this->toString()));
 		return $this;
 	}
 

--- a/lib/lib_pms.php
+++ b/lib/lib_pms.php
@@ -15,6 +15,7 @@ class PMS{
 	var $hookPoints;
 	var $loaded;
 	var $CHPList;
+	var $hooks;
 
 	/* Constructor */
 	function __construct($ENV){

--- a/module/mod_anigif.php
+++ b/module/mod_anigif.php
@@ -23,9 +23,10 @@ class mod_anigif extends ModuleHelper {
 
 	public function autoHookRegistBeforeCommit(&$name, &$email, &$sub, &$com, &$category, &$age, $dest, $isReply, $imgWH, &$status) {
 		$fh = new FlagHelper($status);
-		$size = @getimagesize($dest);
 
-		if(isset($_POST['anigif']) && ($size[2] == 1)) {
+		$size =($dest && is_file($dest)) ? @getimagesize($dest) :[];
+
+		if(isset($_POST['anigif']) && isset($size[2]) && ($size[2] == 1)) {
 			$fh->toggle('agif');
 			$status = $fh->toString();
 		}


### PR DESCRIPTION
- `if(!isset($DNSBLservers[0])||!$DNSBLservers[0])`
An undefined array will be null with an error, so if it is undefined, set it to False.

- Using ${} in strings is deprecated.
${value} → {$value}

- Declare an undeclared class property.

- https://www.php.net/manual/en/functions.arguments.php
>Note that any optional arguments should be specified after any required arguments, otherwise they cannot be omitted from calls.

- Checkd the existence of the image file before getimagesize($dest) to avoid errors when posting text-only in PHP8.x.

I hope it continues to work properly after these changes.
It's working in my XAMPP test environment.
