### PR TITLE
fixd unescaped filename.

### DIFF
--- a/koko.php
+++ b/koko.php
@@ -541,7 +541,7 @@ function regist($preview=false){
 			$size = @getimagesize($dest);
 			$imgsize = @filesize($dest); // File size
 			$imgsize = ($imgsize>=1024) ? (int)($imgsize/1024).' KB' : $imgsize.' B'; // Discrimination of KB and B
-			$fname = pathinfo($upfile_name, PATHINFO_FILENAME);
+			$fname = Cleanstr(pathinfo($upfile_name, PATHINFO_FILENAME));
 			$ext = '.'.strtolower(pathinfo($upfile_name, PATHINFO_EXTENSION));
 			if (is_array($size)) {
 				// File extension detection from Heyuri


### PR DESCRIPTION
If the file name starts with `'`(single quote), the HTML syntax structure will be broken when outputting.
example file name.
`'1695547155091774.png`

`onmouseover="this.textContent=''1695547155091774.png';`

Example of output HTML.
The single quote becomes `''`, breaking the quoting structure.

Therefore, escaping HTML special characters is necessary.

The result after adding the "Cleanstr" function to escape HTML special characters.
`onmouseover="this.textContent='&#039;1695547155091774.png';`

`&#039;` is displayed as `'` on the web browser.