### PR TITLE
catalog.js stuff

### DIFF
--- a/config.php
+++ b/config.php
@@ -180,7 +180,7 @@ define("THUMB_SETTING", array( // Thumbnail Gen. Settings
 $ADDITION_INFO = @file_get_contents(ROOTPATH.'addinfo.txt'); // Addinfo
 $LIMIT_SENSOR = array('ByThreadCountCondition'=>150); // AutoDelete, defaults to 10 pages
 define("TEMPLATE_FILE", 'kokoimg.tpl'); // Template File. Set this and the next line to 'kokotxt.tpl' and 'kokotxtreply.tpl' respectively to use Kokonotsuba as a textboard.
-define("REPLY_TEMPLATE_FILE", 'kokoimgreply.tpl'); // Reply page template file
+define("REPLY_TEMPLATE_FILE", 'kokoimg.tpl'); // Reply page template file
 define("PAGE_DEF", 15); // How many threads per page
 define("ADMIN_PAGE_DEF", 20); // How many threads per page on admin panel
 define("RE_DEF", 5); // Shown Replies on Index

--- a/kokoimg.tpl
+++ b/kokoimg.tpl
@@ -30,7 +30,6 @@
 	<script type="text/javascript" src="https://static.heyuri.net/js/koko/qu2.js"></script>
 	<script type="text/javascript" src="https://static.heyuri.net/js/koko/style.js"></script>
 	<script type="text/javascript" src="https://static.heyuri.net/js/koko/img.js"></script>
-	<script type="text/javascript" src="https://static.heyuri.net/js/koko/catalog.js"></script>
 	<script type="text/javascript" src="https://static.heyuri.net/js/koko/inline.js"></script>
 	<script type="text/javascript" src="https://static.heyuri.net/js/koko/update.js"></script>
 	<script src="https://unpkg.com/@ruffle-rs/ruffle"></script>
@@ -51,9 +50,6 @@
 	<!--&TOPLINKS/-->
 	<center id="header">
 		<div class="logo">
-			<br />
-			<noscript><img border="1" src="https://heyuri.net/banners.php" /></noscript>
-			<script src="https://static.heyuri.net/js/banner.js"></script>
 			<br />
 			<h1 class="mtitle">{$TITLE}</h1>
 			{$TITLESUB}

--- a/module/mod_cat.php
+++ b/module/mod_cat.php
@@ -67,7 +67,9 @@ class mod_cat extends ModuleHelper {
 			$cat_cols = 'auto';
 
 		head($dat);
-		$dat.= '<div id="catalog">
+		$dat.= '
+		<script type="text/javascript" src="https://static.heyuri.net/js/koko/catalog.js"></script>
+		<div id="catalog">
 [<a href="'.PHP_SELF2.'?'.time().'">Return</a>]
 <center class="theading2"><b>Catalog</b></center>';
 


### PR DESCRIPTION
The only difference between img and imgreply templates was catalog.js, which could've been included in mod_cat.php anyways. Maybe for customization reasons kokoimgreply should stay instead of removing it.