### PR TITLE
Remove arbitrary 1 second timer slowing down redirect

### DIFF
--- a/lib/lib_common.php
+++ b/lib/lib_common.php
@@ -146,7 +146,7 @@ function redirect($to, $time=0, $verbose=false) {
 	<html><head>
 		<meta charset="utf-8" />
 		<title>Redirecting...</title>
-		<meta http-equiv="refresh" content="'.($time+1).';URL='.$to.'" />
+		<meta http-equiv="refresh" content="0;URL='.$to.'" />
 		<script>
 	setTimeout(function(){'.$tojs.'}, '.$time.'*1000);
 		</script>


### PR DESCRIPTION
# Pull Requests 4 Kokonotsuba

Removes arbitary timer slowing down the redirect page, making posting faster

- [X] Has been tested
  - Debian 10
  - nginx
  - MariaDB
  - PHP 7.3


