### PR TITLE
Update kokoimg.tpl

### DIFF
--- a/kokoimg.tpl
+++ b/kokoimg.tpl
@@ -22,8 +22,6 @@
 	<link class="linkstyle" rel="stylesheet" type="text/css" href="{$STATIC_URL}/css/heyuriclassic.css" title="Heyuri Classic" />
 	<link class="linkstyle" rel="stylesheet alternate" type="text/css" href="{$STATIC_URL}/css/futaba.css" title="Futaba" />
 	<link class="linkstyle" rel="stylesheet alternate" type="text/css" href="{$STATIC_URL}/css/oldheyuri.css" title="Sakomoto" />
-	
-	<meta http-equiv="cache-control" content="no-cache" />
 	<link rel="shortcut icon" href="static/image/favicon.png" />
 	<script type="text/javascript" src="js/koko.js"></script>
 	<script type="text/javascript" src="js/qu.js"></script>


### PR DESCRIPTION
not tested, but rlly do i need to lol. 
line 14 already has this line. it is used to tell the browser to not cache data so it pulls the most new data.

since can be shows on a static html page. a future optimization is not have that on static pages to have less get request