### PR TITLE
protection against posts being eaten

### DIFF
--- a/js/koko.js
+++ b/js/koko.js
@@ -575,3 +575,34 @@ const kkjs = {
 };
 
 window.addEventListener("DOMContentLoaded", kkjs.startup);
+
+function cacheComment(text) {
+	localStorage.setItem("comment", text.value);
+}
+
+function handleCommentCachingEvent() {
+	let data;
+	data = localStorage.getItem("comment");
+
+	
+	let commentArea = document.getElementById("com");
+	commentArea.setAttribute("onkeyup", "cacheComment(this)");
+	commentArea.value = data;
+	
+	let postform = document.getElementById("postform");
+	//clear comment cache if form is submitted
+	if(postform.addEventListener){
+		postform.addEventListener("submit", function() {
+		localStorage.setItem("comment", '')}, false);
+	}else if(postform.attachEvent){
+		postform.attachEvent('onsubmit', function() {
+		localStorage.setItem("comment", '')}); 
+	}
+
+}
+
+$win.onload = function () {
+	handleCommentCachingEvent();
+}
+
+


### PR DESCRIPTION
this commit stores post comments if the form isn't submitted. Therefore it stops koko eating your post if you accidentally open a different page. Im not sure if koko.js was the best file to put it in but it works in any case.

issue this resolves: https://github.com/Heyuri/kokonotsuba/issues/41#issue-1603625716

tested on: 
  nginx
  arch linux
  php-8.3