### PR TITLE
Change img themes to use div instead of a full table for posts

### DIFF
--- a/kokoimg.tpl
+++ b/kokoimg.tpl
@@ -162,27 +162,23 @@
 			<!--/&THREAD-->
 
 			<!--&REPLY-->
-			<table>
-				<tbody>
-					<tr>
-						<td class="doubledash" valign="top">
-							&gt;&gt;
-						</td>
-						<td class="post reply" id="p{$NO}">
-							<div class="postinfo"><label><input type="checkbox" name="{$NO}" value="delete" /><big class="title"><b>{$SUB}</b></big> {$NAME_TEXT}<span class="name">{$NAME}</span> <span class="time">{$NOW}</span></label>
-								<nobr><span class="postnum">
-										<!--&IF($QUOTEBTN,'<a href="{$SELF}?res={$RESTO}#p{$NO}" class="no">No.</a>{$QUOTEBTN}','<a href="{$SELF}?res={$RESTO}#p{$NO}">No.{$NO}</a>')--></span>{$POSTINFO_EXTRA}</nobr>
-								<small><i class="backlinks">{$BACKLINKS}</i></small>
-							</div>
-							<div class="filesize">{$IMG_BAR}</div>
-							{$IMG_SRC}
-							<blockquote class="comment">{$COM}</blockquote>
-							<!--&IF($CATEGORY,'<small class="category"><i>{$CATEGORY_TEXT}{$CATEGORY}</i></small>','')-->
-							{$WARN_BEKILL}
-						</td>
-					</tr>
-				</tbody>
-			</table>
+			<div class="reply-container">
+				<div class="doubledash" valign="top">
+					&gt;&gt;
+				</div>
+				<div class="post reply" id="p{$NO}">
+					<div class="postinfo"><label><input type="checkbox" name="{$NO}" value="delete" /><big class="title"><b>{$SUB}</b></big> {$NAME_TEXT}<span class="name">{$NAME}</span> <span class="time">{$NOW}</span></label>
+					<nobr><span class="postnum">
+					<!--&IF($QUOTEBTN,'<a href="{$SELF}?res={$RESTO}#p{$NO}" class="no">No.</a>{$QUOTEBTN}','<a href="{$SELF}?res={$RESTO}#p{$NO}">No.{$NO}</a>')--></span>{$POSTINFO_EXTRA}</nobr>
+						<small><i class="backlinks">{$BACKLINKS}</i></small>
+					</div>
+					<div class="filesize">{$IMG_BAR}</div>
+						{$IMG_SRC}
+						<blockquote class="comment">{$COM}</blockquote>
+						<!--&IF($CATEGORY,'<small class="category"><i>{$CATEGORY_TEXT}{$CATEGORY}</i></small>','')-->
+						{$WARN_BEKILL}
+				</div>
+			</div>
 			<!--/&REPLY-->
 
 			<!--&SEARCHRESULT-->

--- a/kokoimgreply.tpl
+++ b/kokoimgreply.tpl
@@ -162,27 +162,38 @@
 			<!--/&THREAD-->
 
 			<!--&REPLY-->
-			<table>
-				<tbody>
-					<tr>
-						<td class="doubledash" valign="top">
-							&gt;&gt;
-						</td>
-						<td class="post reply" id="p{$NO}">
-							<div class="postinfo"><label><input type="checkbox" name="{$NO}" value="delete" /><big class="title"><b>{$SUB}</b></big> {$NAME_TEXT}<span class="name">{$NAME}</span> <span class="time">{$NOW}</span></label>
-								<nobr><span class="postnum">
-										<!--&IF($QUOTEBTN,'<a href="{$SELF}?res={$RESTO}#p{$NO}" class="no">No.</a>{$QUOTEBTN}','<a href="{$SELF}?res={$RESTO}#p{$NO}">No.{$NO}</a>')--></span>{$POSTINFO_EXTRA}</nobr>
-								<small><i class="backlinks">{$BACKLINKS}</i></small>
-							</div>
-							<div class="filesize">{$IMG_BAR}</div>
-							{$IMG_SRC}
-							<blockquote class="comment">{$COM}</blockquote>
-							<!--&IF($CATEGORY,'<small class="category"><i>{$CATEGORY_TEXT}{$CATEGORY}</i></small>','')-->
-							{$WARN_BEKILL}
-						</td>
-					</tr>
-				</tbody>
-			</table>
+			<div class="reply-container">
+				<div class="doubledash" valign="top">
+					&gt;&gt;
+				</div>
+				<div class="post reply" id="p{$NO}">
+					<div class="postinfo"><label><input type="checkbox" name="{$NO}" value="delete" /><big class="title"><b>{$SUB}</b></big> {$NAME_TEXT}<span class="name">{$NAME}</span> <span class="time">{$NOW}</span></label>
+					<nobr><span class="postnum">
+					<!--&IF($QUOTEBTN,'<a href="{$SELF}?res={$RESTO}#p{$NO}" class="no">No.</a>{$QUOTEBTN}','<a href="{$SELF}?res={$RESTO}#p{$NO}">No.{$NO}</a>')--></span>{$POSTINFO_EXTRA}</nobr>
+						<small><i class="backlinks">{$BACKLINKS}</i></small>
+					</div>
+					<div class="filesize">{$IMG_BAR}</div>
+						{$IMG_SRC}
+						<blockquote class="comment">{$COM}</blockquote>
+						<!--&IF($CATEGORY,'<small class="category"><i>{$CATEGORY_TEXT}{$CATEGORY}</i></small>','')-->
+						{$WARN_BEKILL}
+				</div>
+			</div>
+			<!--/&REPLY-->
+
+			<!--&SEARCHRESULT-->
+			<div class="post op">
+				<label><big class="title">{$SUB}</big>
+					{$NAME_TEXT}<span class="name">{$NAME}</span>
+					<span class="time">{$NOW}</span></label> No.{$NO}
+				<blockquote>{$COM}</blockquote>
+				<!--&IF($CATEGORY,'<div class="category">{$CATEGORY_TEXT}{$CATEGORY}</div>','')-->
+			</div>
+			<!--&REALSEPARATE/-->
+			<!--/&SEARCHRESULT-->
+
+			<!--&THREADSEPARATE-->
+		</div>
 			<!--/&REPLY-->
 
 			<!--&SEARCHRESULT-->

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -323,6 +323,7 @@ blockquote {
 
 .doubledash {
 	float: left;
+	padding-right: 2px;
 }
 
 .reply-container {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -298,11 +298,11 @@ audio {
 	}
 	.doubledash {
 		visibility: hidden;
+		float: left;
 	}
 	.thread,
-	.op,
-	.reply {
-		width: 100%;
+	.op {
+	 width:100%;
 	}
 	.postimg {display: block; float: none;}
 	.serve5 {display: none;}
@@ -321,8 +321,17 @@ blockquote {
 	max-width: 100%;
 }
 
+.doubledash {
+	float: left;
+}
+
+.reply-container {
+	margin: 4px 0;	
+}
+
 .reply {
     padding: 2px;
+    display: table;
 }
 
 .post.op:target, .post.op.replyhl {


### PR DESCRIPTION
After stea -- i mean borrowing some css and html from Yotsuba, post replies use div elements instead of an entire table.