### PR TITLE
have debug forced on install script

### DIFF
--- a/install.php
+++ b/install.php
@@ -1,4 +1,9 @@
 <?php
+
+	ini_set('display_errors', '1');
+	ini_set('display_startup_errors', '1');
+	error_reporting(E_ALL);
+
 	require './config.php';
 
 	// Parse the mysql connection string


### PR DESCRIPTION
this should help people figure out what they dont have when trying to set up a instance.

since this file is to be thrown away after install and already has sensitive data. 
it should be fine to have debug text.