### PR TITLE
Ipv6 fixes

### DIFF
--- a/lib/lib_admin.php
+++ b/lib/lib_admin.php
@@ -15,8 +15,7 @@ function admindel(&$dat){
 	$modFunc = '';
 	$delno = $thsno = array();
 	$message = ''; // Display message after deletion
-	preg_match("/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/", $_GET['host'], $hostMatch);
-	$searchHost = $hostMatch[0];
+	$searchHost = filter_var($_GET['host'], FILTER_VALIDATE_IP) ?: filter_var($_GET['host'], FILTER_VALIDATE_DOMAIN);
 	if ($searchHost) {
 		if ($AccountIO->valid() <= LEV_JANITOR) error('ERROR: No Access.');
 		$noticeHost = '<h2>Viewing all posts from: '.$searchHost.'. Click submit to cancel.</h2><br />';

--- a/module/mod_showip.php
+++ b/module/mod_showip.php
@@ -42,9 +42,14 @@ class mod_showip extends ModuleHelper {
 			return;
 		}
 		if (!$post['resto'] && $this->IPTOGGLE == 1) $arrLabels['{$COM}'] .= '<br><br><span style="color: #00C;"><b>Posts in this thread will display IP addresses.</b></span>';
-
 		if(ip2long($iphost)!==false) {
 			$arrLabels['{$NOW}'] .= ' (IP: '.preg_replace('/\d+\.\d+$/','*.*',$iphost).')';
+		} else if (inet_pton($iphost) !== false) { // ipv6
+			$ipv6mask = inet_pton('ffff:ffff::');
+			$ipv6 = inet_pton($iphost);
+			$ipv6 = inet_ntop($ipv6 & $ipv6mask);
+			$ipv6 = rtrim($ipv6, ':').':*';
+			$arrLabels['{$NOW}'] .= ' (IP: '.$ipv6.')';
 		} else { // host
 			$parthost=''; $iscctld = false; $isgtld = false;
 

--- a/module/mod_showip.php
+++ b/module/mod_showip.php
@@ -37,11 +37,14 @@ class mod_showip extends ModuleHelper {
 		$email = ($post['resto'] ? $PIO->fetchPosts($post['resto'])[0]['email'] : $post['email']);
 
 		$iphost = strtolower($post['host']);
+
+		if (!($this->IPTOGGLE == 2) && !($this->IPTOGGLE == 1 && stristr($email, 'displayip'))) {
+			return;
+		}
+		if (!$post['resto'] && $this->IPTOGGLE == 1) $arrLabels['{$COM}'] .= '<br><br><span style="color: #00C;"><b>Posts in this thread will display IP addresses.</b></span>';
+
 		if(ip2long($iphost)!==false) {
-			if ($this->IPTOGGLE == 2 || stristr($email, 'displayip')) {
-				if (!$post['resto'] && $this->IPTOGGLE == 1) $arrLabels['{$COM}'] .= '<br><br><span style="color: #00C;"><b>Posts in this thread will display IP addresses.</b></span>';
-				$arrLabels['{$NOW}'] .= ' (IP: '.preg_replace('/\d+\.\d+$/','*.*',$iphost).')';
-			} 
+			$arrLabels['{$NOW}'] .= ' (IP: '.preg_replace('/\d+\.\d+$/','*.*',$iphost).')';
 		} else { // host
 			$parthost=''; $iscctld = false; $isgtld = false;
 


### PR DESCRIPTION
- fix a mod_showip bug where IP addresses of IPv6 posters are displayed even when not posting in a thread with 'displayip' set
- partially redact IPv6 addresses in mod_showip
- fix "Viewing all posts from" not working with IPv6 addresses