### PR TITLE
$time should be integer

### DIFF
--- a/koko.php
+++ b/koko.php
@@ -415,8 +415,10 @@ function regist($preview=false){
     $pwdc = $_COOKIE['pwdc']??'';
     $ip = getREMOTE_ADDR(); 
     $host = $ip;
+    // Unix timestamp in seconds
     $time = $_SERVER['REQUEST_TIME'];
-    $tim  = sprintf('%d%03d', $time = microtime(true), ($time - floor($time)) * 1000);
+    // Unix timestamp in milliseconds
+    $tim  = intval($_SERVER['REQUEST_TIME_FLOAT'] * 1000);
     $upfile = '';
     $upfile_path = '';
     $upfile_name = '';


### PR DESCRIPTION
This will fix the "Implicit conversion from float 1728582175.10813 to int loses precision" messages that appear in error.log when posting.