### PR TITLE
 Remove board identifier from CDN which currently breaks it 

### DIFF
--- a/code/board/board.php
+++ b/code/board/board.php
@@ -157,7 +157,7 @@ class board implements IBoard {
 		if (!isset($this->config['CDN_URL']) || !$this->boardData->getBoardIdentifier()) {
 			return null;
 		}
-		return $this->config['CDN_URL'] . $this->getBoardUID() . '-' . $this->boardData->getBoardIdentifier() . '/';
+		return $this->config['CDN_URL'] $this->boardData->getBoardIdentifier() . '/';
 	}
 
 	public function getBoardLocalUploadURL(): ?string {

--- a/code/board/board.php
+++ b/code/board/board.php
@@ -157,7 +157,7 @@ class board implements IBoard {
 		if (!isset($this->config['CDN_URL']) || !$this->boardData->getBoardIdentifier()) {
 			return null;
 		}
-		return $this->config['CDN_URL'] $this->boardData->getBoardIdentifier() . '/';
+		return $this->config['CDN_URL'] . '' . '' . $this->boardData->getBoardIdentifier() . '/';
 	}
 
 	public function getBoardLocalUploadURL(): ?string {


### PR DESCRIPTION
I will be making another commit soon that makes the cdn board directory use a some small hexadecimal hash of the board uri rather than the board uri itself. Up to this repositories owners to decide if they want to merge that to. The original CDN feature (only implemented on one site) used a similar method with numbers.