### PR TITLE
correctly check for thread deletion

### DIFF
--- a/code/routers/routes/registRoute.php
+++ b/code/routers/routes/registRoute.php
@@ -221,7 +221,7 @@ class registRoute {
 	
 		$postOpRoot = 0;
 		$flgh = '';
-		$threadDeleted = $this->threadRepository->getThreadByUid($thread_uid, true)['thread_deleted'] ?? false;
+		$threadDeleted = empty($this->threadRepository->getThreadByUid($thread_uid, false));
 		$up_incomplete = 0;
 		$is_admin = $roleLevel === \Kokonotsuba\Root\Constants\userRole::LEV_ADMIN;
 

--- a/code/thread/threadRepository.php
+++ b/code/thread/threadRepository.php
@@ -90,6 +90,8 @@ class threadRepository {
 		// select thread by `thread_uid`
 		$query .= " WHERE thread_uid = :thread_uid";
 
+		$query .= excludeDeletedPostsCondition();
+
 		$params = [':thread_uid' => (string) $thread_uid];
 		
 		$threadData = $this->databaseConnection->fetchOne($query, $params);	


### PR DESCRIPTION
to determine if a thread a user is posting to was deleted, regist route would check the 'thread_deleted' value, which is an aliased column for open_flag of the thread OP. It'd equal to 1 even if the attachment was deleted