### PR TITLE
Type errors + dp preview

### DIFF
--- a/code/board/boardRebuilder.php
+++ b/code/board/boardRebuilder.php
@@ -61,6 +61,13 @@ class boardRebuilder {
 		// get the thread and decide how to fetch its data based on the provided parameters
 		$threadData = $this->getThreadForRendering($uid, $previewCount, $repliesPerPage, $page, $amountOfRepliesToRender);
 		
+		// throw 404 error if no thread data is found
+		// otherwise it'll just dump errors to error log - its data-related and not code-related
+		if ($threadData === false) {
+			throw new BoardException(_T('thread_not_found'), 404);
+			return;
+		}
+
 		// get the thread row
 		$thread = $threadData['thread'];
 
@@ -157,7 +164,7 @@ class boardRebuilder {
 		int $repliesPerPage, 
 		?int $page, 
 		?int $amountOfRepliesToRender
-	): array {
+	): false|array {
 		// Fetch thread with a limited amount of replies	
 		if(!is_null($amountOfRepliesToRender)) {
 			// fetch a 'last X replies' thread

--- a/code/lang/en_US.php
+++ b/code/lang/en_US.php
@@ -230,5 +230,6 @@ $language['comment_too_long'] = "Comment too long, view post %s to see the full 
 $language['post_not_found'] = "Post not found!";
 $language['module_route_not_found'] = "Module route not found!";
 $language['anti_spam_message'] = "Your post was caught by anti-spam rules. Contact staff if you think it was a mistake.";
+$language['thread_not_found_for_deletion'] = "Thread not found for deleted post preview!";
 
 ?>

--- a/code/thread/threadRepository.php
+++ b/code/thread/threadRepository.php
@@ -90,7 +90,10 @@ class threadRepository {
 		// select thread by `thread_uid`
 		$query .= " WHERE thread_uid = :thread_uid";
 
-		$query .= excludeDeletedPostsCondition();
+		// exclude deleted threads if needed
+		if(!$includeDeleted) {
+			$query .= excludeDeletedPostsCondition();
+		}
 
 		$params = [':thread_uid' => (string) $thread_uid];
 		

--- a/module/deletedPosts/deletedPostRenderer.php
+++ b/module/deletedPosts/deletedPostRenderer.php
@@ -187,6 +187,11 @@ class deletedPostRenderer {
 		if($deletedPost['is_op']) {
 			$thread = $this->threadService->getThreadAllReplies($deletedPost['thread_uid'], true, 0);
 
+			// throw error if thread not found
+			if(!$thread) {
+				throw new BoardException(_T('thread_not_found_for_deletion'));
+			}
+
 			// get the post uids from the thread
 			$postUids = $thread['post_uids'];
 		} 


### PR DESCRIPTION
Certain functions wouldn't accept null/false return types which would throw an exception rather than correctly handling it.

There was also an oversight in getThreadByUid which would cause it to exclude deleted threads whether you were logged in or not