### PR TITLE
Misc

### DIFF
--- a/code/Kokonotsuba/board/boardRebuilder.php
+++ b/code/Kokonotsuba/board/boardRebuilder.php
@@ -24,6 +24,7 @@ use function Kokonotsuba\libraries\getPostUidsFromThreadArrays;
 use function Kokonotsuba\libraries\getOrCreateCsrfToken;
 use function Kokonotsuba\libraries\isActiveStaffSession;
 use function Puchiko\strings\html_minify;
+use function Puchiko\strings\sanitizeStr;
 use function Puchiko\strings\truncateText;
 
 class boardRebuilder {
@@ -148,7 +149,7 @@ class boardRebuilder {
 
 		// add CSRF token to delform for logged-in staff on live pages
 		if($this->adminMode) {
-			$pte_vals['{$DELFORM_CSRF}'] = '<input type="hidden" name="csrf_token" value="' . htmlspecialchars(getOrCreateCsrfToken(), ENT_QUOTES, 'UTF-8') . '">';
+			$pte_vals['{$DELFORM_CSRF}'] = '<input type="hidden" name="csrf_token" value="' . sanitizeStr(getOrCreateCsrfToken()) . '">';
 		}
 		
 		// if we want to render the post form then build form html and bind to template parameter
@@ -326,7 +327,7 @@ class boardRebuilder {
 
 		// add CSRF token to delform for logged-in staff on live pages
 		if($this->adminMode) {
-			$pte_vals['{$DELFORM_CSRF}'] = '<input type="hidden" name="csrf_token" value="' . htmlspecialchars(getOrCreateCsrfToken(), ENT_QUOTES, 'UTF-8') . '">';
+			$pte_vals['{$DELFORM_CSRF}'] = '<input type="hidden" name="csrf_token" value="' . sanitizeStr(getOrCreateCsrfToken()) . '">';
 		}
 
 		// build form html

--- a/code/Kokonotsuba/board/boardService.php
+++ b/code/Kokonotsuba/board/boardService.php
@@ -17,6 +17,7 @@ use function Puchiko\createDirectory;
 use function Puchiko\createFileAndWriteText;
 use function Puchiko\rollbackCreatedPaths;
 use function Puchiko\safeRmdir;
+use function Puchiko\strings\sanitizeStr;
 
 /** Service for assembling, creating, editing, and deleting board objects. */
 class boardService {
@@ -219,7 +220,7 @@ class boardService {
 	 * @return string HTML-entity-escaped text.
 	 */
     private function sanitizeTextField($input) {
-        return htmlspecialchars(trim($input), ENT_QUOTES, 'UTF-8');  // Convert special chars to HTML entities
+        return sanitizeStr(trim($input));  // Convert special chars to HTML entities
     }
 
 	/**

--- a/code/Kokonotsuba/libraries/html/helperHtmlFunctions.php
+++ b/code/Kokonotsuba/libraries/html/helperHtmlFunctions.php
@@ -6,6 +6,8 @@
 
 namespace Kokonotsuba\libraries\html;
 
+use function Puchiko\strings\sanitizeStr;
+
 /**
  * Adds hidden input fields for each GET parameter at the top of the provided form HTML.
  *
@@ -17,8 +19,8 @@ function addHiddenGetParamsToForm(string $formHtml, array $getValues): string {
 	$hiddenInputs = '';
 
 	foreach ($getValues as $name => $value) {
-		$nameEscaped = htmlspecialchars($name, ENT_QUOTES, 'UTF-8');
-		$valueEscaped = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+		$nameEscaped = sanitizeStr($name);
+		$valueEscaped = sanitizeStr($value);
 		$hiddenInputs .= "<input type=\"hidden\" name=\"{$nameEscaped}\" value=\"{$valueEscaped}\">\n";
 	}
 

--- a/code/Kokonotsuba/libraries/html/miscPartials.php
+++ b/code/Kokonotsuba/libraries/html/miscPartials.php
@@ -179,9 +179,9 @@ function drawAdminLoginForm(string $adminUrl) {
 }
 	
 function drawAdminTheading(&$dat, $staffSession) {
-	$username = htmlspecialchars($staffSession->getUsername(), ENT_QUOTES, 'UTF-8');
+	$username = sanitizeStr($staffSession->getUsername());
 	$roleEnum = $staffSession->getRoleLevel();
-	$roleName = htmlspecialchars($roleEnum->displayRoleName(), ENT_QUOTES, 'UTF-8');
+	$roleName = sanitizeStr($roleEnum->displayRoleName());
 	
 	$loggedInInfo = '';
 		

--- a/code/Kokonotsuba/libraries/html/postHtmlFunctions.php
+++ b/code/Kokonotsuba/libraries/html/postHtmlFunctions.php
@@ -12,6 +12,7 @@ use Kokonotsuba\post\Post;
 
 use function Puchiko\strings\containsHtmlTags;
 use function Kokonotsuba\libraries\searchBoardArrayForBoard;
+use function Puchiko\strings\sanitizeStr;
 
 /* Generate html for the post name dynamically */
 function generatePostNameHtml(
@@ -45,7 +46,7 @@ function generatePostNameHtml(
 function generateEmailName(string $nameHtml, string $email): string {
 	// if the email isn't empty then wrap it in an <a>
 	if($email) {
-		$escapedEmail = htmlspecialchars($email, ENT_QUOTES, 'UTF-8');
+		$escapedEmail = sanitizeStr($email);
 		return '<a href="mailto:' . $escapedEmail . '">'. $nameHtml . '</a>';
 	} 
 	// no email

--- a/code/Kokonotsuba/libraries/lib_admin.php
+++ b/code/Kokonotsuba/libraries/lib_admin.php
@@ -176,7 +176,7 @@ function generateModerateForm(
 	}
 
 	// Standalone context (admin management pages) — wrap in its own <form>.
-	$csrfToken = htmlspecialchars(getOrCreateCsrfToken(), ENT_QUOTES, 'UTF-8');
+	$csrfToken = sanitizeStr(getOrCreateCsrfToken());
 
 	return '<span class="adminFunctions ' . htmlspecialchars($class) . '">'
 		. '<form method="POST" action="' . htmlspecialchars($buttonUrl) . '" style="display:inline">'

--- a/code/Kokonotsuba/libraries/lib_errorhandler.php
+++ b/code/Kokonotsuba/libraries/lib_errorhandler.php
@@ -2,12 +2,14 @@
 
 namespace Kokonotsuba\libraries;
 
+use function Puchiko\strings\sanitizeStr;
+
 function renderBasicBootstrapErrorPage(string $message): never {
 	http_response_code(500);
 	echo '<!DOCTYPE html>';
 	echo '<html><head><meta charset="UTF-8"><title>Error</title></head><body>';
 	echo '<h1>Error</h1>';
-	echo '<p>' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '</p>';
+	echo '<p>' . sanitizeStr($message) . '</p>';
 	echo '</body></html>';
 	exit;
 }

--- a/code/Kokonotsuba/routers/routes/registRoute.php
+++ b/code/Kokonotsuba/routers/routes/registRoute.php
@@ -40,6 +40,7 @@ use function Kokonotsuba\libraries\scaleThumbnail;
 use function Puchiko\strings\strlenUnicode;
 use function Kokonotsuba\libraries\_T;
 use function Kokonotsuba\libraries\getPageOfThread;
+use function Kokonotsuba\libraries\isActiveStaffSession;
 use function Kokonotsuba\libraries\searchBoardArrayForBoardByIdentifier;
 use function Puchiko\json\sendAjaxAndDetach;
 
@@ -799,7 +800,11 @@ class registRoute {
 			return [];
 		}
 
-		$templateEngine = $this->board->getBoardTemplateEngine();
+		// Switch to the reply template for rendering
+		// clone it so it doesn't affect page rebuild
+		$templateEngine = clone $this->board->getBoardTemplateEngine();
+		$replyTemplateName = $this->board->getConfigValue('REPLY_TEMPLATE_FILE');
+		$templateEngine->setTemplateFile($replyTemplateName);
 
 		$newPostUids = array_map(fn($p) => $p->getUid(), $newPosts);
 		$quoteLinksFromBoard = $this->quoteLinkService->getQuoteLinksByPostUids($newPostUids);
@@ -825,7 +830,7 @@ class registRoute {
 				$threadResno,
 				false,
 				$threadPosts,
-				false,
+				isActiveStaffSession(),
 				'',
 				'',
 				$replyCount,

--- a/module/bbCode/moduleMain.php
+++ b/module/bbCode/moduleMain.php
@@ -9,6 +9,9 @@ use Kokonotsuba\module_classes\traits\listeners\CommentExtrasListenerTrait;
 use Kokonotsuba\module_classes\traits\listeners\IncludeScriptTrait;
 use Kokonotsuba\module_classes\traits\FormattingDetailsTrait;
 
+use function Puchiko\request\sanitizeHeaderInjection;
+use function Puchiko\strings\sanitizeStr;
+
 class moduleMain extends abstractModuleMain { 
 	use PostCommentListenerTrait;
 	use CommentExtrasListenerTrait;
@@ -115,7 +118,7 @@ class moduleMain extends abstractModuleMain {
 		}
 
 		foreach ($simpleButtons as $btn) {
-			$buttons .= '<button type="button" class="bbcodeButton" data-code="' . htmlspecialchars($btn['code'], ENT_QUOTES, 'UTF-8') . '" title="' . htmlspecialchars($btn['title'], ENT_QUOTES, 'UTF-8') . '">' . $btn['label'] . '</button>';
+			$buttons .= '<button type="button" class="bbcodeButton" data-code="' . sanitizeStr($btn['code']) . '" title="' . sanitizeStr($btn['title']) . '">' . $btn['label'] . '</button>';
 		}
 
 		// Selector buttons - rendered as HTML with data-type, JS builds the dropdowns
@@ -280,7 +283,7 @@ class moduleMain extends abstractModuleMain {
 		// image (restrict to http/https/ftp only)
 		if($this->supportImg && (($this->ImgTagTagMode == 2) || ($this->ImgTagTagMode && !$files))){
 			$string = preg_replace_callback('#\[img\](((https?|ftp)://([^ \n\r]+?)))\[\/img\]#si', function($m) {
-				$url = htmlspecialchars($m[1], ENT_QUOTES, 'UTF-8');
+				$url = sanitizeStr($m[1]);
 				return '<img class="bbcodeIMG" src="' . $url . '" style="border:1px solid #021a40;" alt="' . $url . '">';
 			}, $string);
 		}
@@ -541,27 +544,27 @@ class moduleMain extends abstractModuleMain {
 
 	private function _URLConv1($m){
 		++$this->urlcount;
-		$url = htmlspecialchars($m[1].$m[2], ENT_QUOTES, 'UTF-8');
+		$url = sanitizeStr($m[1].$m[2]);
 		return '<a class="bbcodeA" href="'.$url.'" rel="nofollow noreferrer" target="_blank">'.$url.'</a>';
 	}
 
 	private function _URLConv2($m){
 		++$this->urlcount;
-		$url = htmlspecialchars($m[1], ENT_QUOTES, 'UTF-8');
+		$url = sanitizeStr($m[1]);
 		return '<a class="bbcodeA" href="http://'.$url.'" rel="nofollow noreferrer" target="_blank">'.$url.'</a>';
 	}
 
 	private function _URLConv3($m){
 		++$this->urlcount;
-		$href = htmlspecialchars($m[1].$m[2], ENT_QUOTES, 'UTF-8');
-		$text = htmlspecialchars($m[3], ENT_QUOTES, 'UTF-8');
+		$href = sanitizeStr($m[1].$m[2]);
+		$text = sanitizeStr($m[3]);
 		return '<a class="bbcodeA" href="'.$href.'" rel="nofollow noreferrer" target="_blank">'.$text.'</a>';
 	}
 
 	private function _URLConv4($m){
 		++$this->urlcount;
-		$url = htmlspecialchars($m[1], ENT_QUOTES, 'UTF-8');
-		$text = htmlspecialchars($m[2], ENT_QUOTES, 'UTF-8');
+		$url = sanitizeStr($m[1]);
+		$text = sanitizeStr($m[2]);
 		return '<a class="bbcodeA" href="http://'.$url.'" rel="nofollow noreferrer" target="_blank">'.$text.'</a>';
 	}
 

--- a/module/csrfPrevent/moduleMain.php
+++ b/module/csrfPrevent/moduleMain.php
@@ -7,6 +7,8 @@ use Kokonotsuba\module_classes\abstractModuleMain;
 use Kokonotsuba\module_classes\traits\listeners\RegistBeginListenerTrait;
 use Kokonotsuba\module_classes\traits\listeners\PostFormListenerTrait;
 
+use function Puchiko\strings\sanitizeStr;
+
 class moduleMain extends abstractModuleMain {
 	use RegistBeginListenerTrait;
 	use PostFormListenerTrait;
@@ -35,7 +37,7 @@ class moduleMain extends abstractModuleMain {
 	}
 
 	public function onRenderPostForm(string &$postForm): void {
-		$token = htmlspecialchars($this->getSessionToken(), ENT_QUOTES, 'UTF-8');
+		$token = sanitizeStr($this->getSessionToken());
 		$postForm .= '<input type="hidden" name="' . self::TOKEN_FIELD . '" value="' . $token . '">';
 	}
 

--- a/module/emotes/moduleMain.php
+++ b/module/emotes/moduleMain.php
@@ -8,6 +8,8 @@ use Kokonotsuba\module_classes\traits\listeners\CommentExtrasListenerTrait;
 use Kokonotsuba\module_classes\traits\listeners\IncludeScriptTrait;
 use Kokonotsuba\module_classes\traits\FormattingDetailsTrait;
 
+use function Puchiko\strings\sanitizeStr;
+
 class moduleMain extends abstractModuleMain {
 	use PostCommentListenerTrait;
 	use CommentExtrasListenerTrait;
@@ -57,8 +59,8 @@ class moduleMain extends abstractModuleMain {
 		}
 		$buttons = '';
 		foreach ($this->emotes as $emo => $name) {
-			$url = htmlspecialchars($this->baseEmoteUrl . $name);
-			$value = htmlspecialchars(':' . $emo . ':');
+			$url = sanitizeStr($this->baseEmoteUrl . $name);
+			$value = sanitizeStr(':' . $emo . ':');
 			$buttons .= '<button type="button" class="buttonEmote emoteButton" title="' . $value . '">'
 				. '<img class="emoteImage" src="' . $url . '" loading="lazy" title="' . $value . '" alt="' . $value . '">'
 				. '</button>';
@@ -73,8 +75,8 @@ class moduleMain extends abstractModuleMain {
 		}
 		$buttons = '';
 		foreach ($this->kaomoji as $display => $value) {
-			$escapedValue = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
-			$escapedDisplay = htmlspecialchars($display, ENT_QUOTES, 'UTF-8');
+			$escapedValue = sanitizeStr($value);
+			$escapedDisplay = sanitizeStr($display);
 			$buttons .= '<button type="button" class="buttonSJIS kaomojiButton" title="' . $escapedValue . '" data-value="' . $escapedValue . '">'
 				. '<span class="ascii" title="' . $escapedValue . '">' . $escapedDisplay . '</span>'
 				. '</button>';

--- a/module/notes/moduleAdmin.php
+++ b/module/notes/moduleAdmin.php
@@ -393,7 +393,7 @@ class moduleAdmin extends abstractModuleAdmin {
 			'postNumber' => $postNumber,
 			'template' => [
 				'{$NOTE_ID}' => $noteId,
-				'{$NOTE_TEXT}' => htmlspecialchars($note['note_text'] ?? '', ENT_QUOTES),
+				'{$NOTE_TEXT}' => sanitizeStr($note['note_text'] ?? ''),
 				'{$NOTE_VISIBILITY_DESCRIPTION}' => _T('note_visibility_description')
 			]
 		]);

--- a/module/soudane/moduleMain.php
+++ b/module/soudane/moduleMain.php
@@ -14,6 +14,7 @@ use function Kokonotsuba\libraries\isActiveStaffSession;
 use function Kokonotsuba\libraries\validatePostInput;
 use function Puchiko\json\renderJsonErrorPage;
 use function Puchiko\json\renderJsonPage;
+use function Puchiko\strings\sanitizeStr;
 
 require_once __DIR__ . '/soudaneRepository.php';
 require_once __DIR__ . '/soudaneService.php';
@@ -74,15 +75,15 @@ class moduleMain extends abstractModuleMain {
 		$class = $voteCount > 0 ? 'hasVotes' : 'noVotes';
 		$buttonText = $this->getVoteButtonText($type, $voteCount);
 
-		$postUidEsc = htmlspecialchars((string) $postUid, ENT_QUOTES, 'UTF-8');
-		$moduleUrlEsc = htmlspecialchars($this->moduleUrl, ENT_QUOTES, 'UTF-8');
+		$postUidEsc = sanitizeStr((string) $postUid);
+		$moduleUrlEsc = sanitizeStr($this->moduleUrl);
 
 		return
-			'<span class="' . htmlspecialchars($wrapperClass) . '" title="' . htmlspecialchars($title) . '">' .
+			'<span class="' . sanitizeStr($wrapperClass) . '" title="' . sanitizeStr($title) . '">' .
 				'<a id="vote_' . $type . '_' . $postUidEsc . '" ' .
-				'class="sod ' . htmlspecialchars($class) . '" ' .
+				'class="sod ' . sanitizeStr($class) . '" ' .
 				'href="javascript:soudane.vote(\'' . $postUidEsc . '\', \'' . $type . '\', \'' . $moduleUrlEsc . '\');">' .
-					htmlspecialchars($buttonText) .
+					sanitizeStr($buttonText) .
 				'</a>' .
 			'</span>';
 	}
@@ -90,9 +91,9 @@ class moduleMain extends abstractModuleMain {
 	private function renderScore(int $postUid, string $scoreText): string {
     	return
     	    '<span class="soundaneScoreContainer">
-				<span id="vote_score_' . htmlspecialchars((string) $postUid, ENT_QUOTES, 'UTF-8') . '" ' .
+				<span id="vote_score_' . sanitizeStr((string) $postUid) . '" ' .
     	          'class="voteScore">' .
-    	        htmlspecialchars($scoreText) . '
+    	        sanitizeStr($scoreText) . '
 				</span>
 			</span>';
 	}

--- a/templates/kokotxt/HEADER.tpl
+++ b/templates/kokotxt/HEADER.tpl
@@ -5,7 +5,6 @@
 	<script src="{$STATIC_URL}js/qu3.js?v=23" defer></script>
 	<script src="{$STATIC_URL}js/style.js?v=3"></script>
 	<script src="{$STATIC_URL}js/css-vars-ponyfill.js" defer></script>
-	<script src="{$STATIC_URL}js/catalog.js"></script>
 	<script src="{$STATIC_URL}js/insert.js"></script>
 	<script src="{$STATIC_URL}js/admin.js?v=5" defer></script>
 	<script src="{$STATIC_URL}js/select-all-feature.js?v=4" defer></script>

--- a/templates/kokotxtreply/HEADER.tpl
+++ b/templates/kokotxtreply/HEADER.tpl
@@ -5,7 +5,6 @@
 	<script src="{$STATIC_URL}js/qu3.js?v=23" defer></script>
 	<script src="{$STATIC_URL}js/style.js?v=3"></script>
 	<script src="{$STATIC_URL}js/css-vars-ponyfill.js" defer></script>
-	<script src="{$STATIC_URL}js/catalog.js"></script>
 	<script src="{$STATIC_URL}js/insert.js"></script>
 	<script src="{$STATIC_URL}js/update.js" defer></script>
 	<script src="{$STATIC_URL}js/admin.js?v=5" defer></script>


### PR DESCRIPTION
use sanitizeStr instead of htmlspecialchars($str, ENT_QUOTES, 'UTF-8')

also fix noko replies on non-kokoimg templates

as well as remove catalog.js from old templates